### PR TITLE
Add Sphinx documentation with Furo theme and numpy-style docstrings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,19 @@
+# Minimal makefile for Sphinx documentation
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,41 @@
+API Reference
+=============
+
+.. module:: lifegraph
+
+Lifegraph
+---------
+
+.. autoclass:: lifegraph.Lifegraph
+   :members:
+   :undoc-members:
+
+Side
+----
+
+.. autoclass:: lifegraph.core.Side
+   :members:
+   :undoc-members:
+
+Core data structures
+--------------------
+
+.. automodule:: lifegraph.core
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: Side
+
+Configuration
+-------------
+
+.. automodule:: lifegraph.configuration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utilities
+---------
+
+.. automodule:: lifegraph.utils
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,61 @@
+"""Sphinx configuration for lifegraph documentation."""
+
+import os
+import sys
+
+# -- Path setup --------------------------------------------------------------
+sys.path.insert(0, os.path.abspath(".."))
+
+import lifegraph
+
+# -- Project information -----------------------------------------------------
+project = "lifegraph"
+copyright = "2024, Kyle Shores"
+author = "Kyle Shores"
+version = lifegraph.__version__
+release = lifegraph.__version__
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Napoleon settings -------------------------------------------------------
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = True
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+# -- Autodoc settings --------------------------------------------------------
+autodoc_member_order = "bysource"
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+}
+
+# -- Intersphinx mapping -----------------------------------------------------
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+}
+
+# -- Options for HTML output -------------------------------------------------
+html_theme = "furo"
+html_title = "lifegraph"
+html_static_path = ["_static"]
+
+html_theme_options = {
+    "source_repository": "https://github.com/kyleshores/Life-Graph",
+    "source_branch": "main",
+    "source_directory": "docs/",
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,44 @@
+lifegraph
+=========
+
+**lifegraph** visualises your life as a grid of weekly squares, inspired by
+the `Wait But Why <https://waitbutwhy.com/2014/05/life-weeks.html>`_ blog
+post.
+
+.. image:: ../examples/images/alife.png
+   :alt: Example life graph
+   :align: center
+   :width: 60%
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install lifegraph
+
+Quick start
+-----------
+
+.. code-block:: python
+
+   from lifegraph import Lifegraph
+   from datetime import date
+
+   g = Lifegraph(date(1990, 11, 1))
+   g.add_title("My Life")
+   g.save("my_life.png")
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   tutorial
+   api
+
+Indices and tables
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,34 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have
+	echo.Sphinx installed, then set the SPHINXBUILD environment variable
+	echo.to point to the full path of the 'sphinx-build' executable.
+	echo.Alternatively, you may install Sphinx and try again:
+	echo.  https://www.sphinx-doc.org/
+	echo.
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/lifegraph/__init__.py
+++ b/lifegraph/__init__.py
@@ -1,4 +1,23 @@
-"""LifeGraph: A Python package for creating and manipulating life graphs."""
+"""
+LifeGraph
+=========
+
+A Python package for visualizing your life as a grid of weeks.
+
+Inspired by the `Wait But Why <https://waitbutwhy.com/2014/05/life-weeks.html>`_
+blog post, lifegraph lets you create a poster-sized chart where each square
+represents one week of your life, with support for annotated events, colored
+eras, and custom styling.
+
+Examples
+--------
+>>> from lifegraph import Lifegraph, Side
+>>> from datetime import date
+>>> g = Lifegraph(date(1990, 1, 1))
+>>> g.add_life_event("Started college", date(2008, 8, 25), color="blue")
+>>> g.save("my_life.png")
+"""
+
 __version__ = "0.2.0"
 
 from .lifegraph import Lifegraph, Side

--- a/lifegraph/configuration.py
+++ b/lifegraph/configuration.py
@@ -1,7 +1,22 @@
 from enum import Enum
 
 class Papersize(Enum):
-    """A class holding papersize in inches"""
+    """Supported paper sizes for the life graph figure.
+
+    Each member maps to standard paper dimensions (in inches) that
+    determine the default figure size and all proportional styling
+    parameters.  ISO A-series sizes range from A0 (33.1 x 46.8 in) to
+    A10 (1.0 x 1.5 in).  US sizes include Letter (8.5 x 11 in), Legal,
+    JuniorLegal, HalfLetter, Ledger, and Tabloid.  The default for
+    :class:`~lifegraph.Lifegraph` is ``Papersize.A3``.
+
+    Examples
+    --------
+    >>> from lifegraph import Lifegraph
+    >>> from lifegraph.configuration import Papersize
+    >>> from datetime import date
+    >>> g = Lifegraph(date(1990, 1, 1), size=Papersize.Letter)
+    """
     A0 = 1, #[33.1, 46.8] inches
     A1 = 2, #[23.4, 33.1] inches
     A2 = 3, #[16.5, 23.4] inches
@@ -22,7 +37,33 @@ class Papersize(Enum):
 
 
 class LifegraphParams:
-    """A class that defines the defaults for drawing by papersize"""
+    """Drawing parameters scaled to a particular paper size.
+
+    On construction, two dictionaries are populated:
+
+    * ``rcParams`` -- values forwarded to :func:`matplotlib.pyplot.rcParams.update`.
+    * ``otherParams`` -- lifegraph-specific styling knobs (annotation offsets,
+      watermark size, era-span line widths, etc.).
+
+    Parameters
+    ----------
+    papersize : Papersize
+        The paper size to configure for.
+
+    Attributes
+    ----------
+    rcParams : dict
+        Matplotlib RC parameter overrides.
+    otherParams : dict
+        Lifegraph-specific styling parameters.
+
+    Examples
+    --------
+    >>> from lifegraph.configuration import LifegraphParams, Papersize
+    >>> params = LifegraphParams(Papersize.A4)
+    >>> params.rcParams["figure.figsize"]
+    [8.3, 11.7]
+    """
 
     def __init__(self, papersize):
         d = None

--- a/lifegraph/core.py
+++ b/lifegraph/core.py
@@ -1,87 +1,141 @@
 from enum import Enum
 
 class Side(Enum):
-    """Visually indicates the left or right of the plot"""
+    """Specify which side of the plot to place an annotation.
+
+    Use ``Side.LEFT`` to place the label to the left of the grid or
+    ``Side.RIGHT`` to place it to the right.
+
+    Examples
+    --------
+    >>> from lifegraph import Lifegraph, Side
+    >>> from datetime import date
+    >>> g = Lifegraph(date(1990, 1, 1))
+    >>> g.add_life_event("Event", date(2000, 6, 1), side=Side.LEFT)
+    """
     LEFT = 1
     RIGHT = 2
 
 class Point:
-    """A point class that holds the x and y coordinates in data units"""
+    """A 2-D point in data coordinates.
+
+    Parameters
+    ----------
+    x : float
+        The x coordinate.
+    y : float
+        The y coordinate.
+
+    Examples
+    --------
+    >>> from lifegraph.core import Point
+    >>> p = Point(10, 20)
+    >>> p.x
+    10
+    """
     def __init__(self, x, y):
-        """ Initialize the Point class
-
-        :param x: The x coordinate
-        :param y: The y coordinate
-
-        """
         self.x = x
         self.y = y
     def __repr__(self):
-        """Print a description of the Point class"""
         return f"({self.x}, {self.y})"
     def __str__(self):
-        """Print a description of the Point class"""
         return f"({self.x}, {self.y})"
 
 class DatePosition(Point):
-    """A class to hold the week, year of life, and date associated with a Point"""
+    """A point on the grid associated with a calendar date.
+
+    Extends :class:`Point` to additionally store the date that maps to the
+    ``(week, year_of_life)`` grid coordinate.
+
+    Parameters
+    ----------
+    x : int
+        Week number (1--52).
+    y : int
+        Year of life (0-indexed from birthdate).
+    date : datetime.date
+        The calendar date this position represents.
+
+    Examples
+    --------
+    >>> from lifegraph.core import DatePosition
+    >>> from datetime import date
+    >>> dp = DatePosition(10, 5, date(1995, 3, 1))
+    >>> dp.date
+    datetime.date(1995, 3, 1)
+    """
     def __init__(self, x, y, date):
-        """Initialize the DatePosition class. The base class is a Point
-
-        :param x: x coordinate passsed to Point class
-        :param y: y coordinate passsed to Point class
-        :param date: The date associated with the position
-
-        """
         super().__init__(x, y)
         self.date = date
     def __repr__(self):
-        """Print a description of the DatePosition class"""
         return f"DatePosition: year({self.y}), week({self.x}), date({self.date}) at point {super().__repr__()}"
     def __str__(self):
-        """Print a description of the DatePosition class"""
         return f"DatePosition: year({self.y}), week({self.x}), date({self.date}) at point {super().__repr__()}"
 
 class Marker(Point):
-    """A class to indicate how and where to draw a marker"""
+    """Configuration for a colored marker drawn on the grid.
+
+    Extends :class:`Point` with matplotlib marker styling attributes.
+
+    Parameters
+    ----------
+    x : float
+        The x position of the marker.
+    y : float
+        The y position of the marker.
+    marker : str, optional
+        A matplotlib marker style. Default is ``'s'`` (square).
+    fillstyle : str, optional
+        A matplotlib fill style. Default is ``'none'``.
+    color : str or tuple, optional
+        A matplotlib color. Default is ``'black'``.
+
+    Examples
+    --------
+    >>> from lifegraph.core import Marker
+    >>> m = Marker(5, 10, color='red')
+    """
     def __init__(self, x, y, marker='s', fillstyle='none', color='black'):
-        """A class to configure the marker on the graph. The base is a Point class
-
-        :param x: The x position of a marker
-        :param y: The y position of a marker
-        :param marker: (Default value = 's') A matplotlib marker
-        :param fillstyle: (Default value = 'none') A matplotlib fillstyle
-        :param color: (Default value = 'black') A matplotlib color
-
-        """
         super().__init__(x, y)
         self.marker = marker
         self.fillstyle = fillstyle
         self.color = color
     def __repr__(self):
-        """Print a description of the Marker class"""
         return f"Marker at {super().__repr__()}"
     def __str__(self):
-        """Print a description of the Marker class"""
         return f"Marker at {super().__repr__()}"
 
 class Annotation(Point):
-    """A class to hold the text of an annotation with methods to help layout the text."""
+    """A text annotation with layout-conflict resolution support.
+
+    Holds the label text and its position, along with metadata used by
+    :class:`~lifegraph.lifegraph.Lifegraph` to prevent overlapping labels.
+
+    Parameters
+    ----------
+    date : datetime.date
+        When the annotated event occurred.
+    text : str
+        The label text.
+    label_point : Point
+        Initial location for the label text.
+    color : str or tuple, optional
+        A matplotlib color. Default is ``'black'``.
+    bbox : matplotlib.transforms.Bbox or None, optional
+        The bounding box of the rendered text. Set after layout.
+    event_point : Point or None, optional
+        Where on the grid the event is located.
+    put_circle_around_point : bool, optional
+        Whether to draw a circle around the event square. Default is ``True``.
+    marker : Marker or None, optional
+        A :class:`Marker` to draw at the event position.
+    relpos : tuple of float, optional
+        The relative position on the label from which the annotation arrow
+        originates. See `matplotlib annotation guide
+        <https://matplotlib.org/tutorials/text/annotations.html>`_.
+        Default is ``(0.5, 0.5)``.
+    """
     def __init__(self, date, text, label_point, color='black', bbox=None, event_point=None, put_circle_around_point=True, marker=None, relpos=(.5, .5)):
-        """Initialize the Annotation class. THe base is a Point class.
-
-        :param date: When the event occurred
-        :param text: The label text of the annotation
-        :param label_point: The location of the label text
-        :param color: (Default value = 'black') A matplotlib color
-        :param bbox: (Default value = None) The bounding box of the point
-        :param event_point: (Default value = None) Where on the graph the event is located
-        :param put_circle_around_point: (Default value = True) Should the event point be circled on the graph
-        :param shrink: (Default value = 0) How much from the event point should the arrow stop
-        :param marker: (Default value = None) A Marker class
-        :param relpos: (Default value = (.5, .5)) The position that the annotation arrow innitates from on the label, see https://matplotlib.org/tutorials/text/annotations.html
-
-        """
         super().__init__(label_point.x, label_point.y)
         self.date = date
         self.text = text
@@ -92,30 +146,45 @@ class Annotation(Point):
         self.marker = marker
         self.relpos = relpos
     def set_bbox(self, bbox):
-        """Set the bounding box of an annotation
+        """Set the bounding box of the rendered annotation text.
 
-        :param bbox: a matplotlib.transforms.Bbox instance
-
+        Parameters
+        ----------
+        bbox : matplotlib.transforms.Bbox
+            The bounding box in data coordinates.
         """
         self.bbox = bbox
     def set_relpos(self, relpos):
-        """Set the relative position that the arrow should draw from
+        """Set the arrow origin relative to the label bounding box.
 
-        see https://matplotlib.org/tutorials/text/annotations.html
-
-        :param relpos: a tuple whose values range from [0, 1]
-
+        Parameters
+        ----------
+        relpos : tuple of float
+            ``(rx, ry)`` where each value is in ``[0, 1]``. See the
+            `matplotlib annotation guide
+            <https://matplotlib.org/tutorials/text/annotations.html>`_.
         """
         self.relpos = relpos
     def overlaps(self, that):
-        """Check that the two Bboxes don't overlap
-        
-        They don't overlap if
-            1) one rectangle's left side is strictly to the right other's right side
-            2) one rectangle's top side is stricly bellow the other's bottom side
+        """Check whether this annotation's bounding box overlaps another's.
 
-        :param that: an Annotation
+        Two boxes do *not* overlap when one is entirely to the right of the
+        other, or entirely below the other.
 
+        Parameters
+        ----------
+        that : Annotation
+            The other annotation to test against.
+
+        Returns
+        -------
+        bool
+            ``True`` if the bounding boxes overlap.
+
+        Raises
+        ------
+        ValueError
+            If *that* is not an :class:`Annotation`.
         """
         if (not isinstance(that, Annotation)):
             raise ValueError("Argument for intersects should be an annotation")
@@ -125,11 +194,24 @@ class Annotation(Point):
             return False
         return True
     def is_within_epsilon_of(self, that, epsilon):
-        """Check that the two are not at least as close as some epsilon
+        """Check whether two annotations are closer than a tolerance.
 
-        :param that: An Annotation
-        :param epsilon: A real number to define the tolerance for how close the label text can be
+        Parameters
+        ----------
+        that : Annotation
+            The other annotation.
+        epsilon : float
+            Minimum allowed distance between bounding boxes.
 
+        Returns
+        -------
+        bool
+            ``True`` if the annotations are within *epsilon* of each other.
+
+        Raises
+        ------
+        ValueError
+            If *that* is not an :class:`Annotation`.
         """
         if (not isinstance(that, Annotation)):
             raise ValueError("Argument for intersects should be an annotation")
@@ -139,11 +221,24 @@ class Annotation(Point):
             return False
         return True
     def get_bbox_overlap(self, that, epsilon):
-        """Determine by how much the two annotation bounding boxes overlap
+        """Compute the overlap dimensions between two annotation bounding boxes.
 
-        :param that: an Annotation
-        :param epsilon: A real number that will add a buffer space between the two label text bounding boxes
+        Parameters
+        ----------
+        that : Annotation
+            The other annotation.
+        epsilon : float
+            Buffer added to the height calculation.
 
+        Returns
+        -------
+        tuple of float
+            ``(width, height)`` of the overlap region.
+
+        Raises
+        ------
+        ValueError
+            If *that* is not an :class:`Annotation`.
         """
         if (not isinstance(that, Annotation)):
             raise ValueError("Argument for intersects should be an annotation")
@@ -152,11 +247,24 @@ class Annotation(Point):
         height = abs(that.bbox.ymax - self.bbox.ymin) + epsilon
         return (width, height)
     def get_xy_correction(self, that, epsilon):
-        """Detmerine by how much the two annotation bounding boxes overlap
+        """Compute the correction needed to resolve an overlap.
 
-        :param that: an Annotation
-        :param epsilon: A real number that will add a buffer space between the two label text bounding boxes
+        Parameters
+        ----------
+        that : Annotation
+            The other annotation.
+        epsilon : float
+            Buffer added to the correction.
 
+        Returns
+        -------
+        tuple of float
+            ``(dx, dy)`` correction to apply.
+
+        Raises
+        ------
+        ValueError
+            If *that* is not an :class:`Annotation`.
         """
         if (not isinstance(that, Annotation)):
             raise ValueError("Argument for intersects should be an annotation")
@@ -164,67 +272,99 @@ class Annotation(Point):
         height = abs(that.bbox.ymax - self.bbox.ymin) + epsilon
         return (width, height)
     def update_X_with_correction(self, correction):
-        """Move the label text in the x direction according to the value in correction
+        """Shift the label in the x direction.
 
-        :param correction: a tuple of real number where correction[0] determines by how much the x position of the label should move
-
+        Parameters
+        ----------
+        correction : tuple of float
+            ``correction[0]`` is added to the x position and bounding box.
         """
         self.x += correction[0]
         self.bbox.x0 += correction[0]
         self.bbox.x1 += correction[0]
     def update_Y_with_correction(self, correction):
-        """Move the label text in the y direction according to the value in correction
+        """Shift the label in the y direction.
 
-        :param correction: a tuple of real number where correction[1] determines by how much the y position of the label should move
-
+        Parameters
+        ----------
+        correction : tuple of float
+            ``correction[1]`` is added to the y position and bounding box.
         """
         self.y += correction[1]
         self.bbox.y0 += correction[1]
         self.bbox.y1 += correction[1]
     def __repr__(self):
-        """Print a description of the Annotation class"""
         return f"Annotation '{self.text}' at {super().__repr__()}"
     def __str__(self):
-        """Print a description of the Annotation class"""
         return f"Annotation '{self.text}' at {super().__repr__()}"
 
 class Era():
-    """A class which shows a highlighted area on the graph to indicate a span of time"""
+    """A highlighted region on the grid representing a period of time.
+
+    Eras are drawn as colored rectangles spanning from ``start`` to ``end``
+    behind the grid squares.
+
+    Parameters
+    ----------
+    text : str
+        Label for the era.
+    start : datetime.date
+        Start date of the era.
+    end : datetime.date
+        End date of the era.
+    color : str or tuple
+        A matplotlib color.
+    alpha : float, optional
+        Opacity of the era rectangle. Default is ``1``.
+
+    Examples
+    --------
+    >>> from lifegraph import Lifegraph
+    >>> from datetime import date
+    >>> g = Lifegraph(date(1990, 1, 1))
+    >>> g.add_era("College", date(2008, 9, 1), date(2012, 5, 15), color="blue")
+    """
     def __init__(self, text, start, end, color, alpha=1):
-        """Initialize the Era class
-
-        :param text: The text to place on the graph
-        :param start: A datetime.date indicating the start of the era
-        :param end: A datetime.date indicating the end of the era
-        :param color: A color useable by any matplotlib object
-        :param alpha: (Default value = 1)
-
-        """
         self.text = text
         self.start = start
         self.end = end
         self.color = color
         self.alpha = alpha
     def __repr__(self):
-        """Print a description of the Era class"""
         return f"Era '{self.text}' starting at {self.start}, ending at {self.end}"
     def __str__(self):
-        """Print a description of the Era class"""
         return f"Era '{self.text}' starting at {self.start}, ending at {self.end}"
 
 class EraSpan(Era):
-    """A class which shows a dumbbell shape on the graph defining a span of your life"""
+    """A dumbbell-shaped annotation marking a span of time.
+
+    Draws circles at the start and end positions connected by a line,
+    with an optional label.
+
+    Parameters
+    ----------
+    text : str
+        Label for the era span.
+    start : datetime.date
+        Start date.
+    end : datetime.date
+        End date.
+    color : str or tuple
+        A matplotlib color.
+    start_marker : Marker or None, optional
+        Custom marker for the start position.
+    end_marker : Marker or None, optional
+        Custom marker for the end position.
+
+    Examples
+    --------
+    >>> from lifegraph import Lifegraph
+    >>> from datetime import date
+    >>> g = Lifegraph(date(1990, 1, 1))
+    >>> g.add_era_span("Grad school", date(2012, 9, 1), date(2016, 5, 15),
+    ...               color="#4423fe")
+    """
     def __init__(self, text, start, end, color, start_marker=None, end_marker=None):
-        """Initalize the Era span class. The base is an Era.
-
-        :param text: The text to place on the graph
-        :param start: A datetime.date indicating the start of the era
-        :param end: A datetime.date indicating the end of the era
-        :param color: A color useable by any matplotlib object
-        :param start_marker: (Default = None) A marker for the starting point if one is wanted different than the default of the graph
-        :param end_marker: (Default = None) A marker for the ending point if one is wanted different than the default of the graph
-
-        """
         super().__init__(text, start, end, color)
         self.start_marker = start_marker
         self.end_marker = end_marker

--- a/lifegraph/lifegraph.py
+++ b/lifegraph/lifegraph.py
@@ -12,20 +12,56 @@ from lifegraph.utils import random_color
 
 
 class Lifegraph:
-    """This class will represent your life as a graph of boxes"""
+    """Visualize a life as a grid of weekly squares.
+
+    Each row represents one year of life and each column one week, creating
+    a 52-column by *max_age*-row grid.  Events, eras, and other annotations
+    can be added and are automatically laid out to avoid overlapping labels.
+
+    Parameters
+    ----------
+    birthdate : datetime.date
+        The date to anchor the grid.  Row 0, column 1 corresponds to the
+        first week of life.
+    size : Papersize, optional
+        Paper size that controls default figure dimensions and styling
+        parameters.  Default is ``Papersize.A3``.
+    dpi : int, optional
+        Resolution in dots per inch.  Default is ``300``.
+    label_space_epsilon : float, optional
+        Minimum gap (in data units) the layout engine keeps between
+        annotation labels.  Default is ``0.2``.
+    max_age : int, optional
+        Number of rows (years) in the grid.  Default is ``90``.
+    axes_rect : list of float, optional
+        ``[left, bottom, width, height]`` passed to
+        :meth:`matplotlib.figure.Figure.add_axes`.  Ignored when *ax* is
+        provided.  Default is ``[0.25, 0.1, 0.5, 0.8]``.
+    ax : matplotlib.axes.Axes or None, optional
+        An existing axes to draw on.  When provided, the caller is
+        responsible for the figure lifecycle (saving, showing, closing).
+        Default is ``None`` (a new figure is created).
+
+    Examples
+    --------
+    Create a basic life graph and save it:
+
+    >>> from lifegraph import Lifegraph
+    >>> from datetime import date
+    >>> g = Lifegraph(date(1990, 11, 1))
+    >>> g.save("my_life.png")
+
+    Use a provided axes for subplot composition:
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
+    >>> g = Lifegraph(date(1990, 11, 1), ax=ax, max_age=50)
+    >>> g.draw()
+    >>> fig.savefig("subplot.png")
+    >>> plt.close(fig)
+    """
 
     def __init__(self, birthdate, size=Papersize.A3, dpi=300, label_space_epsilon=0.2, max_age=90, axes_rect = [.25, .1, .5, .8], ax=None):
-        """Initialize the life graph
-
-        :param birthdate: The date to start the graph from
-        :param size:  (Default value = Papersize.A3) A papersize in inches
-        :param dpi: (Default value = 300) Dots per inch
-        :param label_space_epsilon: (Default value = .2) The minimum amount of space allowed between annotation text objects
-        :param max_age: (Default value = 90) The ending age of the graph
-        :param axes_rect: (Default value = [.25, .1, .5, .8]) The dimensions [left, bottom, width, height] of the axes instance passed to matplotlib.figure.Figure.add_axes. This parameter is ignored when ax is provided.
-        :param ax: (Default value = None) An optional matplotlib axes instance to draw on. If provided, lifegraph will draw on this axes instead of creating its own figure and axes.
-
-        """
         if birthdate is None or not isinstance(birthdate, datetime.date):
             raise ValueError("birthdate must be a valid datetime.date object")
 
@@ -71,14 +107,26 @@ class Lifegraph:
 
     #region Public drawing methods
     def format_x_axis(self, text=None, positionx=None, positiony=None, color=None, fontsize=None):
-        """Format the x axis. This method is required.
+        """Customise the x-axis label appearance.
 
-        :param text: (Default value = None), If present, changes the text of the x-axis
-        :param positionx: (Default value = None) If present, changes the location of the x postion of the x-axis (in axes coordaintes)
-        :param positiony: (Default value = None) If present, changes the location of the y postion of the x-axis (in axes coordaintes)
-        :param color: (Default value = None) A matplotlib color
-        :param fontsize: (Default value = None) A matplotlib fontsize
+        All parameters are optional; only the supplied values are changed.
 
+        Parameters
+        ----------
+        text : str or None, optional
+            Replacement label text.
+        positionx : float or None, optional
+            X position of the label in axes coordinates.
+        positiony : float or None, optional
+            Y position of the label in axes coordinates.
+        color : str or tuple or None, optional
+            A matplotlib color.
+        fontsize : float or None, optional
+            Font size in points.
+
+        Examples
+        --------
+        >>> g.format_x_axis(text="Weeks", color="red", fontsize=14)
         """
         if text is not None:
             self.xaxis_label = text
@@ -97,14 +145,26 @@ class Lifegraph:
             self.settings.otherParams["xlabel.fontsize"] = fontsize
 
     def format_y_axis(self, text=None, positionx=None, positiony=None, color=None, fontsize=None):
-        """Format the y axis. This method is required.
+        """Customise the y-axis label appearance.
 
-        :param text: (Default value = None), If present, changes the text of the y-axis
-        :param positionx: (Default value = None) If present, changes the location of the x postion of the y-axis (in axes coordaintes)
-        :param positiony: (Default value = None) If present, changes the location of the y postion of the y-axis (in axes coordaintes)
-        :param color: (Default value = None) A matplotlib color
-        :param fontsize: (Default value = None) A matplotlib fontsize
+        All parameters are optional; only the supplied values are changed.
 
+        Parameters
+        ----------
+        text : str or None, optional
+            Replacement label text.
+        positionx : float or None, optional
+            X position of the label in axes coordinates.
+        positiony : float or None, optional
+            Y position of the label in axes coordinates.
+        color : str or tuple or None, optional
+            A matplotlib color.
+        fontsize : float or None, optional
+            Font size in points.
+
+        Examples
+        --------
+        >>> g.format_y_axis(text="Your Age", color="green")
         """
         if text is not None:
             self.xaxis_label = text
@@ -123,19 +183,52 @@ class Lifegraph:
             self.settings.otherParams["ylabel.fontsize"] = fontsize
 
     def show_max_age_label(self):
-        """Places the max age on the bottom right of the plot"""
+        """Display the maximum age number at the bottom-right of the grid.
+
+        Examples
+        --------
+        >>> g = Lifegraph(date(1990, 1, 1), max_age=100)
+        >>> g.show_max_age_label()
+        """
         self.draw_max_age = True
 
     def add_life_event(self, text, date, color=None, hint=None, side=None, color_square=True):
-        """Label an event in your life
+        """Add a labeled event to the graph.
 
-        :param text: The text the should appear for the life event
-        :param date: (Default value = None) When the event occurred
-        :param color: (Default value = None) A color useable by any matplotlib object
-        :param hint: (Default value = None) Mutually exclusive with side. Not required. If the default placement is not desired. A Point may be provided to help the graph decide where to place the label of the event.
-        :param side: (Default value = None) Mutually exclusive with hint. Not required. If not provided, the side is determined by the date. If provided, this value will put the label on the given side of the plot
-        :param color_square: (Default value = True) Colors the sqaure on the graph the same color as the text if True. The sqaure is the default color of the graph squares otherwise
+        The event position on the grid is calculated from the birthdate and
+        the event *date*.  An arrow connects the label text to the
+        corresponding grid square.
 
+        Parameters
+        ----------
+        text : str
+            Label text for the event.
+        date : datetime.date
+            When the event occurred.
+        color : str or tuple or None, optional
+            A matplotlib color.  A random color is chosen when ``None``.
+        hint : Point or tuple or None, optional
+            Approximate label position in data coordinates.  Mutually
+            exclusive with *side*.
+        side : Side or None, optional
+            Force the label to :attr:`Side.LEFT` or :attr:`Side.RIGHT`.
+            Mutually exclusive with *hint*.
+        color_square : bool, optional
+            If ``True`` (default), the grid square is colored to match the
+            label.
+
+        Raises
+        ------
+        ValueError
+            If *date* is outside the range ``[birthdate, birthdate + max_age)``.
+
+        Examples
+        --------
+        >>> from lifegraph import Lifegraph, Side
+        >>> from datetime import date
+        >>> g = Lifegraph(date(1990, 11, 1))
+        >>> g.add_life_event("Graduated", date(2012, 5, 20), color="#00FF00")
+        >>> g.add_life_event("Moved abroad", date(2015, 3, 1), side=Side.LEFT)
         """
         if (date < self.birthdate or date > (relativedelta(years=self.ymax) + self.birthdate)):
             raise ValueError(
@@ -158,15 +251,38 @@ class Lifegraph:
         self.annotations.append(a)
 
     def add_era(self, text, start_date, end_date, color=None, side=None, alpha=0.3):
-        """Color in a section of your life
+        """Highlight a period of your life with a colored background.
 
-        :param text: The label text for the era
-        :param start_date: When the event started
-        :param end_date: When the event ended
-        :param color: A color useable by any matplotlib object
-        :param side: (Default value = None) Mutually exclusive with hint. Not required. If not provided, the side is determined by the date. If provided, this value will put the label on the given side of the plot
-        :param alpha: (Default value = 0.3) the alpha value of the color
+        The background spans from *start_date* to *end_date* behind the grid
+        squares.
 
+        Parameters
+        ----------
+        text : str
+            Label text for the era.
+        start_date : datetime.date
+            When the era started.
+        end_date : datetime.date
+            When the era ended.
+        color : str or tuple or None, optional
+            A matplotlib color.  A random color is chosen when ``None``.
+        side : Side or None, optional
+            Force the label to a specific side of the grid.
+        alpha : float, optional
+            Opacity of the colored background.  Default is ``0.3``.
+
+        Raises
+        ------
+        ValueError
+            If either date is outside the valid range.
+
+        Examples
+        --------
+        >>> from lifegraph import Lifegraph
+        >>> from datetime import date
+        >>> g = Lifegraph(date(1990, 1, 1))
+        >>> g.add_era("College", date(2008, 9, 1), date(2012, 5, 15),
+        ...           color="blue", alpha=0.2)
         """
         if (start_date < self.birthdate or start_date > (relativedelta(years=self.ymax) + self.birthdate)):
             raise ValueError(
@@ -197,16 +313,43 @@ class Lifegraph:
         self.annotations.append(a)
 
     def add_era_span(self, text, start_date, end_date, color=None, hint=None, side=None, color_start_and_end_markers=False):
-        """Add a dumbbell around a section of your life
+        """Add a dumbbell-shaped annotation marking a time span.
 
-        :param text: The text labeling the span
-        :param start_date: When the era started
-        :param end_date: When the era ended
-        :param color: (Default value = random_color()) A matplotlib color
-        :param hint: (Default value = None) Mutually exclusive with side, a Point indicating where the label should be placed. This position will be honored if possible
-        :param side: (Default value = None) Mutually exclusive with hint. If Side.LEFT, the label will be on the left of the graph. Is Side.RIGHT, the label will be placed on the ride side of the graph
-        :param color_start_and_end_markers: Default value = False) Colors the sqaures indicating the start and end date on the graph the same color as the text if True. The sqaures are the default color of the graph squares otherwise
+        Circles are drawn at the start and end grid positions, connected by
+        a line, with a label pointing to the midpoint.
 
+        Parameters
+        ----------
+        text : str
+            Label text for the era span.
+        start_date : datetime.date
+            When the span started.
+        end_date : datetime.date
+            When the span ended.
+        color : str or tuple or None, optional
+            A matplotlib color.  A random color is chosen when ``None``.
+        hint : Point or tuple or None, optional
+            Approximate label position in data coordinates.  Mutually
+            exclusive with *side*.
+        side : Side or None, optional
+            Force the label to a specific side.  Mutually exclusive with
+            *hint*.
+        color_start_and_end_markers : bool, optional
+            If ``True``, the start and end grid squares are colored to match
+            the label.  Default is ``False``.
+
+        Raises
+        ------
+        ValueError
+            If either date is outside the valid range.
+
+        Examples
+        --------
+        >>> from lifegraph import Lifegraph
+        >>> from datetime import date
+        >>> g = Lifegraph(date(1990, 1, 1))
+        >>> g.add_era_span("Road trip", date(2015, 6, 1),
+        ...                date(2015, 8, 30), color="#D2691E")
         """
         if (start_date < self.birthdate or start_date > (relativedelta(years=self.ymax) + self.birthdate)):
             raise ValueError(
@@ -243,68 +386,114 @@ class Lifegraph:
                                            color=color, event_point=event_point, put_circle_around_point=False))
 
     def add_watermark(self, text):
-        """Adds a watermark to the graph. 
-        
-        If this function is not called, no watermark is drawn.
+        """Add diagonal watermark text across the graph.
 
-        :param text: The text of the watermark
+        Parameters
+        ----------
+        text : str
+            The watermark text.
 
+        Examples
+        --------
+        >>> g.add_watermark("DRAFT")
         """
         self.watermark_text = text
 
     def add_title(self, text, fontsize=None):
-        """Adds a title to the graph.
+        """Add a title above the graph.
 
-        If this function is not called, no title is drawn.
+        Parameters
+        ----------
+        text : str
+            Title text.
+        fontsize : float or None, optional
+            Font size in points.  Uses the paper-size default when ``None``.
 
-        :param text: The text to display as the title of the graph
-        :param fontsize: (Default value = None)
-
+        Examples
+        --------
+        >>> g.add_title("The Life of Ada Lovelace")
         """
         self.title = text
         if fontsize is not None:
             self.title_fontsize = fontsize
 
     def add_image(self, image_name, alpha=1):
-        """Adds an image that is cliped to the axes size of the graph.
+        """Overlay an image on the graph axes.
 
-        If this function is not called, no image is drawn.
+        The image is stretched to fill the grid area.
 
-        :param image_name: param alpha:  (Default value = 1)
-        :param alpha:  (Default value = 1)
+        Parameters
+        ----------
+        image_name : str
+            Path to the image file.
+        alpha : float, optional
+            Opacity of the image overlay.  Default is ``1``.
 
+        Examples
+        --------
+        >>> g.add_image("background.jpg", alpha=0.5)
         """
         self.image_name = image_name
         self.image_alpha = alpha
 
     def draw(self):
-        """Draw the graph onto the axes.
+        """Render the graph onto the axes.
 
-        This is useful when using a provided axes instance and you want to
-        trigger rendering without saving or showing. For example, when composing
-        multiple subplots and saving the figure yourself.
+        Call this explicitly when using a provided *ax* and you want to
+        trigger rendering before saving or showing the figure yourself.
+
+        Examples
+        --------
+        >>> import matplotlib.pyplot as plt
+        >>> fig, ax = plt.subplots()
+        >>> g = Lifegraph(date(1990, 1, 1), ax=ax, max_age=50)
+        >>> g.draw()
+        >>> fig.savefig("out.png")
+        >>> plt.close(fig)
         """
         self.__draw()
 
     def show(self):
-        """Show the graph"""
+        """Render the graph and display it interactively.
+
+        When using a provided axes, the caller should call
+        :func:`matplotlib.pyplot.show` on their own figure instead.
+
+        Examples
+        --------
+        >>> g = Lifegraph(date(1990, 1, 1))
+        >>> g.add_title("My Life")
+        >>> g.show()
+        """
         self.__draw()
         if self.owns_figure:
             plt.show()
         # If not owning the figure, the user should call plt.show() on their figure
 
     def close(self):
-        """Close the graph"""
+        """Close the figure and free resources.
+
+        Only has an effect when the figure was created internally (i.e. no
+        *ax* was provided).
+        """
         if self.owns_figure and hasattr(self, 'fig'):
             self.fig.clf()
             plt.close()
 
     def save(self, name, transparent=False):
-        """Save the graph.
+        """Render the graph and save it to a file.
 
-        :param name: The name and location the file should be saved at
-        :param transparent: Default value = False)
+        Parameters
+        ----------
+        name : str
+            Output file path (e.g. ``"my_life.png"``).
+        transparent : bool, optional
+            Save with a transparent background.  Default is ``False``.
 
+        Examples
+        --------
+        >>> g = Lifegraph(date(1990, 1, 1))
+        >>> g.save("my_life.png")
         """
         self.__draw()
         # Always save the figure, regardless of ownership
@@ -318,7 +507,7 @@ class Lifegraph:
         # If already drawn and using provided axes, skip redrawing to avoid duplicates
         if self._already_drawn and not self.owns_figure:
             return
-            
+
         plt.rcParams.update(self.settings.rcParams)
 
         # Use provided axes or create new figure and axes
@@ -346,7 +535,7 @@ class Lifegraph:
         self.__draw_max_age()
 
         self.ax.set_aspect('equal', share=True)
-        
+
         # Mark as drawn to prevent duplicate drawing with provided axes
         self._already_drawn = True
 
@@ -383,7 +572,7 @@ class Lifegraph:
 
     def __draw_annotations(self):
         """Internal, put all of the annotations on the graph
-        
+
         The arrowprops keyword arguments to the annotation, shrinkB, is calculated so that
         regardless of plot size, the edge of the annotaiton line ends at the edge of the circle
         """
@@ -436,7 +625,7 @@ class Lifegraph:
         This is done by placing a circle around the start and end point. Then a line is drawn
         starting at the edge of each circle. The edge is found using a quadrant sensitive inverse
         tangent function and parametric equations of a circle.
-        
+
         """
         for era in self.era_spans:
             radius = .5
@@ -508,7 +697,7 @@ class Lifegraph:
 
     def __resolve_annotation_conflicts(self, annotations):
         """Internal, Put annotation text labels on the graph while avoiding conflicts.
-        
+
         This method decides the final (x, y) coordinates for the graph such that
         no two text label bounding boxes overlap. This happens by placing the labels
         from the top of the graph to the bottom. If any label were to overlap with

--- a/lifegraph/utils.py
+++ b/lifegraph/utils.py
@@ -9,6 +9,22 @@ for key, val in mcolors.CSS4_COLORS.items():
         colors.append((key, val))
 
 def random_color():
-    """Returns a random color defined in matplotlib.colors.BASE_COLORS or matplotlib.colors.CSS4_COLORS"""
+    """Return a random color from matplotlib's named color sets.
+
+    Selects a random color from the union of
+    :data:`matplotlib.colors.BASE_COLORS` and
+    :data:`matplotlib.colors.CSS4_COLORS`.
+
+    Returns
+    -------
+    str or tuple
+        A color value accepted by matplotlib (e.g. ``'red'`` or
+        ``(1.0, 0.0, 0.0)``).
+
+    Examples
+    --------
+    >>> from lifegraph.utils import random_color
+    >>> c = random_color()
+    """
     c = random.choice(colors)
     return c[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,10 @@ dev = [
     "pytest",
     "pytest-cov"
 ]
+
+docs = [
+    "sphinx>=7.0",
+    "furo",
+    "sphinx-copybutton",
+    "sphinx-autodoc-typehints",
+]


### PR DESCRIPTION
Set up docs/ with Sphinx, Furo theme, autodoc, napoleon, and intersphinx. Convert all public API docstrings from Sphinx-style to numpy-style with examples. Add a tutorial covering all major features and a full API reference. Include .readthedocs.yaml for deployment and docs optional dependency group in pyproject.toml.