### PR TITLE
Add JSON/YAML import/export for lifegraph configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ g.show_max_age_label()
 g.save("images/alife.png")
 ```
 
+## Saving and Loading Configurations
+
+Export a lifegraph to a portable JSON or YAML file and recreate it later:
+
+```python
+# Export
+g.save_config("my_life.json")
+g.save_config("my_life.yaml", include_styling=True)  # requires: pip install lifegraph[yaml]
+
+# Import
+g = Lifegraph.from_config("my_life.json")
+g.save("my_life.png")
+```
+
 For tutorials, API reference, and more examples, see the [full documentation](https://lifegraph.readthedocs.io/en/latest/).
 
 # Contributing and Code of Conduct

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,12 @@ Configuration
    :undoc-members:
    :show-inheritance:
 
+Serialization
+-------------
+
+.. automodule:: lifegraph.serialization
+   :members: CONFIG_VERSION, export_config, import_config
+
 Utilities
 ---------
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -287,6 +287,69 @@ Mixing lifegraph with other plots
    fig.savefig("mixed_plots.png", dpi=300)
    plt.close(fig)
 
+Saving and loading configurations
+---------------------------------
+
+You can export a lifegraph to a portable JSON or YAML file and later
+recreate the exact same graph from that file.  This is useful for sharing
+configurations, version-controlling your life data separately from code,
+or building tools on top of the format.
+
+Exporting to JSON
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   g = Lifegraph(birthday, dpi=300, size=Papersize.Letter)
+   g.add_life_event("Graduated", date(2012, 5, 20), color="#00FF00")
+   g.add_era("College", date(2008, 9, 1), date(2012, 5, 15), color="blue")
+   g.add_title("My Life")
+
+   g.save_config("my_life.json")
+
+The format is inferred from the file extension: ``.json`` for JSON,
+``.yaml`` or ``.yml`` for YAML.
+
+Including axis styling
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default, axis label customisations are not included.  Pass
+``include_styling=True`` to export them:
+
+.. code-block:: python
+
+   g.format_x_axis(text="Weeks", color="red", fontsize=14)
+   g.save_config("my_life_styled.json", include_styling=True)
+
+Importing from a config file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   g = Lifegraph.from_config("my_life.json")
+   g.save("my_life.png")
+
+If the file contains a ``styling`` section, it is applied by default.
+Pass ``apply_styling=False`` to ignore it:
+
+.. code-block:: python
+
+   g = Lifegraph.from_config("my_life_styled.json", apply_styling=False)
+
+YAML support
+~~~~~~~~~~~~
+
+YAML requires the optional ``pyyaml`` package:
+
+.. code-block:: bash
+
+   pip install lifegraph[yaml]
+
+.. code-block:: python
+
+   g.save_config("my_life.yaml")
+   g2 = Lifegraph.from_config("my_life.yaml")
+
 Putting it all together
 -----------------------
 

--- a/lifegraph/serialization.py
+++ b/lifegraph/serialization.py
@@ -1,0 +1,343 @@
+import datetime
+import json
+from pathlib import Path
+
+from lifegraph.configuration import Papersize
+from lifegraph.core import Point, Side
+
+
+CONFIG_VERSION = 1
+
+
+def _infer_format(path):
+    ext = Path(path).suffix.lower()
+    if ext == ".json":
+        return "json"
+    if ext in (".yaml", ".yml"):
+        return "yaml"
+    raise ValueError(f"Unsupported config file extension '{ext}'. Use .json, .yaml, or .yml.")
+
+
+def _get_yaml():
+    try:
+        import yaml
+        return yaml
+    except ImportError:
+        raise ImportError(
+            "PyYAML is required for YAML support. Install it with: pip install pyyaml"
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+def _serialize_date(d):
+    return d.isoformat()
+
+
+def _serialize_color(c):
+    if isinstance(c, tuple):
+        return list(c)
+    return c
+
+
+def _serialize_hint(h):
+    if h is None:
+        return None
+    if isinstance(h, Point):
+        return [h.x, h.y]
+    if isinstance(h, (list, tuple)):
+        return [h[0], h[1]]
+    return None
+
+
+def _serialize_side(s):
+    if s is None:
+        return None
+    if isinstance(s, Side):
+        return s.name.lower()
+    return s
+
+
+def _build_config_dict(graph, include_styling):
+    d = {
+        "version": CONFIG_VERSION,
+        "birthdate": _serialize_date(graph.birthdate),
+    }
+
+    if graph.ymax != 90:
+        d["max_age"] = graph.ymax
+
+    if graph.settings.size != Papersize.A3:
+        d["size"] = graph.settings.size.name
+
+    if graph.settings.rcParams["figure.dpi"] != 300:
+        d["dpi"] = graph.settings.rcParams["figure.dpi"]
+
+    if graph.label_space_epsilon != 0.2:
+        d["label_space_epsilon"] = graph.label_space_epsilon
+
+    if graph.title is not None:
+        if graph.title_fontsize is not None:
+            d["title"] = {"text": graph.title, "fontsize": graph.title_fontsize}
+        else:
+            d["title"] = graph.title
+
+    if graph.watermark_text is not None:
+        d["watermark"] = graph.watermark_text
+
+    if graph.image_name is not None:
+        img = {"path": graph.image_name}
+        if graph.image_alpha != 1:
+            img["alpha"] = graph.image_alpha
+        d["image"] = img
+
+    if graph.draw_max_age:
+        d["show_max_age_label"] = True
+
+    if graph._event_records:
+        events = []
+        for rec in graph._event_records:
+            ev = {
+                "text": rec["text"],
+                "date": _serialize_date(rec["date"]),
+                "color": _serialize_color(rec["color"]),
+            }
+            hint = _serialize_hint(rec.get("hint"))
+            if hint is not None:
+                ev["hint"] = hint
+            side = _serialize_side(rec.get("side"))
+            if side is not None:
+                ev["side"] = side
+            if not rec.get("color_square", True):
+                ev["color_square"] = False
+            events.append(ev)
+        d["events"] = events
+
+    if graph._era_records:
+        eras = []
+        for rec in graph._era_records:
+            era = {
+                "text": rec["text"],
+                "start_date": _serialize_date(rec["start_date"]),
+                "end_date": _serialize_date(rec["end_date"]),
+                "color": _serialize_color(rec["color"]),
+            }
+            side = _serialize_side(rec.get("side"))
+            if side is not None:
+                era["side"] = side
+            if rec.get("alpha") != 0.3:
+                era["alpha"] = rec["alpha"]
+            eras.append(era)
+        d["eras"] = eras
+
+    if graph._era_span_records:
+        spans = []
+        for rec in graph._era_span_records:
+            span = {
+                "text": rec["text"],
+                "start_date": _serialize_date(rec["start_date"]),
+                "end_date": _serialize_date(rec["end_date"]),
+                "color": _serialize_color(rec["color"]),
+            }
+            hint = _serialize_hint(rec.get("hint"))
+            if hint is not None:
+                span["hint"] = hint
+            side = _serialize_side(rec.get("side"))
+            if side is not None:
+                span["side"] = side
+            if rec.get("color_start_and_end_markers"):
+                span["color_start_and_end_markers"] = True
+            spans.append(span)
+        d["era_spans"] = spans
+
+    if include_styling:
+        styling = {}
+
+        x_ax = {}
+        if graph.xaxis_label != r'Week of the Year $\longrightarrow$':
+            x_ax["text"] = graph.xaxis_label
+        x_pos = graph.settings.otherParams["xlabel.position"]
+        if x_pos != (0.20, 1.05):
+            x_ax["positionx"] = x_pos[0]
+            x_ax["positiony"] = x_pos[1]
+        if graph.settings.otherParams["xlabel.color"] is not None:
+            x_ax["color"] = _serialize_color(graph.settings.otherParams["xlabel.color"])
+        if graph.settings.otherParams["xlabel.fontsize"] is not None:
+            x_ax["fontsize"] = graph.settings.otherParams["xlabel.fontsize"]
+        if x_ax:
+            styling["x_axis"] = x_ax
+
+        y_ax = {}
+        if graph.yaxis_label != r'$\longleftarrow$ Age':
+            y_ax["text"] = graph.yaxis_label
+        y_pos = graph.settings.otherParams["ylabel.position"]
+        if y_pos != (-0.03, 0.95):
+            y_ax["positionx"] = y_pos[0]
+            y_ax["positiony"] = y_pos[1]
+        if graph.settings.otherParams["ylabel.color"] is not None:
+            y_ax["color"] = _serialize_color(graph.settings.otherParams["ylabel.color"])
+        if graph.settings.otherParams["ylabel.fontsize"] is not None:
+            y_ax["fontsize"] = graph.settings.otherParams["ylabel.fontsize"]
+        if y_ax:
+            styling["y_axis"] = y_ax
+
+        if styling:
+            d["styling"] = styling
+
+    return d
+
+
+def export_config(graph, path, include_styling=False):
+    fmt = _infer_format(path)
+    d = _build_config_dict(graph, include_styling)
+
+    with open(path, "w") as f:
+        if fmt == "json":
+            json.dump(d, f, indent=2)
+        else:
+            yaml = _get_yaml()
+            yaml.dump(d, f, default_flow_style=False, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Deserialization helpers
+# ---------------------------------------------------------------------------
+
+def _parse_date(s):
+    return datetime.date.fromisoformat(s)
+
+
+def _parse_color(c):
+    if isinstance(c, list):
+        return tuple(c)
+    return c
+
+
+def _parse_hint(h):
+    if h is None:
+        return None
+    if isinstance(h, list):
+        return Point(h[0], h[1])
+    return h
+
+
+def _parse_side(s):
+    if s is None:
+        return None
+    if isinstance(s, str):
+        return Side[s.upper()]
+    return s
+
+
+def _parse_papersize(s):
+    if s is None:
+        return Papersize.A3
+    if isinstance(s, str):
+        return Papersize[s]
+    return s
+
+
+def import_config(cls, path, apply_styling=True):
+    fmt = _infer_format(path)
+
+    with open(path) as f:
+        if fmt == "json":
+            d = json.load(f)
+        else:
+            yaml = _get_yaml()
+            d = yaml.safe_load(f)
+
+    version = d.get("version", 1)
+    if version != CONFIG_VERSION:
+        raise ValueError(f"Unsupported config version {version}. Expected {CONFIG_VERSION}.")
+
+    birthdate = _parse_date(d["birthdate"])
+    size = _parse_papersize(d.get("size"))
+    dpi = d.get("dpi", 300)
+    label_space_epsilon = d.get("label_space_epsilon", 0.2)
+    max_age = d.get("max_age", 90)
+
+    graph = cls(birthdate, size=size, dpi=dpi,
+                label_space_epsilon=label_space_epsilon, max_age=max_age)
+
+    # Title
+    title = d.get("title")
+    if title is not None:
+        if isinstance(title, str):
+            graph.add_title(title)
+        elif isinstance(title, dict):
+            graph.add_title(title["text"], fontsize=title.get("fontsize"))
+
+    # Watermark
+    watermark = d.get("watermark")
+    if watermark is not None:
+        graph.add_watermark(watermark)
+
+    # Image
+    image = d.get("image")
+    if image is not None:
+        graph.add_image(image["path"], alpha=image.get("alpha", 1))
+
+    # Show max age label
+    if d.get("show_max_age_label"):
+        graph.show_max_age_label()
+
+    # Events
+    for ev in d.get("events", []):
+        graph.add_life_event(
+            text=ev["text"],
+            date=_parse_date(ev["date"]),
+            color=_parse_color(ev.get("color")),
+            hint=_parse_hint(ev.get("hint")),
+            side=_parse_side(ev.get("side")),
+            color_square=ev.get("color_square", True),
+        )
+
+    # Eras
+    for era in d.get("eras", []):
+        graph.add_era(
+            text=era["text"],
+            start_date=_parse_date(era["start_date"]),
+            end_date=_parse_date(era["end_date"]),
+            color=_parse_color(era.get("color")),
+            side=_parse_side(era.get("side")),
+            alpha=era.get("alpha", 0.3),
+        )
+
+    # Era spans
+    for span in d.get("era_spans", []):
+        graph.add_era_span(
+            text=span["text"],
+            start_date=_parse_date(span["start_date"]),
+            end_date=_parse_date(span["end_date"]),
+            color=_parse_color(span.get("color")),
+            hint=_parse_hint(span.get("hint")),
+            side=_parse_side(span.get("side")),
+            color_start_and_end_markers=span.get("color_start_and_end_markers", False),
+        )
+
+    # Styling
+    if apply_styling and "styling" in d:
+        styling = d["styling"]
+        if "x_axis" in styling:
+            x = styling["x_axis"]
+            graph.format_x_axis(
+                text=x.get("text"),
+                positionx=x.get("positionx"),
+                positiony=x.get("positiony"),
+                color=_parse_color(x.get("color")),
+                fontsize=x.get("fontsize"),
+            )
+        if "y_axis" in styling:
+            y = styling["y_axis"]
+            graph.format_y_axis(
+                text=y.get("text"),
+                positionx=y.get("positionx"),
+                positiony=y.get("positiony"),
+                color=_parse_color(y.get("color")),
+                fontsize=y.get("fontsize"),
+            )
+
+    return graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,13 @@ Homepage = "https://github.com/kyleshores/Life-Graph"
 
 [project.optional-dependencies]
 
+yaml = ["pyyaml>=5.0"]
+
 dev = [
     "pytest",
     "pytest-cov",
-    "ruff"
+    "ruff",
+    "pyyaml>=5.0"
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "ruff",
-    "pyyaml>=5.0"
+    "pyyaml>=5.1"
 ]
 
 docs = [

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,307 @@
+import datetime
+import json
+
+import pytest
+
+from lifegraph.lifegraph import Lifegraph, Side
+from lifegraph.configuration import Papersize
+from lifegraph.core import Point
+from lifegraph.serialization import _infer_format, CONFIG_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Format inference
+# ---------------------------------------------------------------------------
+
+def test_infer_format_json():
+    assert _infer_format("config.json") == "json"
+
+
+def test_infer_format_yaml():
+    assert _infer_format("config.yaml") == "yaml"
+    assert _infer_format("config.yml") == "yaml"
+
+
+def test_infer_format_unsupported():
+    with pytest.raises(ValueError, match="Unsupported"):
+        _infer_format("config.txt")
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip: minimal
+# ---------------------------------------------------------------------------
+
+def test_json_roundtrip_minimal(tmp_path):
+    g = Lifegraph(datetime.date(1995, 11, 20), dpi=300)
+    path = tmp_path / "minimal.json"
+    g.save_config(str(path))
+
+    g2 = Lifegraph.from_config(str(path))
+    assert g2.birthdate == datetime.date(1995, 11, 20)
+    assert g2.ymax == 90
+    assert g2.settings.rcParams["figure.dpi"] == 300
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip: full
+# ---------------------------------------------------------------------------
+
+def test_json_roundtrip_full(tmp_path):
+    g = Lifegraph(datetime.date(1995, 11, 20), dpi=300, size=Papersize.Letter,
+                  label_space_epsilon=1.0, max_age=80)
+    g.add_life_event("Won award", datetime.date(2013, 11, 20), "#014421",
+                     hint=(25, -3), color_square=True)
+    g.add_life_event("Moved", datetime.date(2015, 3, 1), "blue", side=Side.LEFT)
+    g.add_era("College", datetime.date(2014, 9, 1), datetime.date(2018, 12, 14),
+              (0.314, 0, 0), side=Side.LEFT, alpha=0.5)
+    g.add_era_span("Vacation", datetime.date(2016, 8, 22), datetime.date(2016, 12, 16),
+                   "#D2691E", hint=Point(53, 28))
+    g.add_title("My Life", fontsize=24)
+    g.add_watermark("DRAFT")
+    g.show_max_age_label()
+
+    path = tmp_path / "full.json"
+    g.save_config(str(path))
+
+    g2 = Lifegraph.from_config(str(path))
+    assert g2.birthdate == datetime.date(1995, 11, 20)
+    assert g2.ymax == 80
+    assert g2.settings.size == Papersize.Letter
+    assert g2.label_space_epsilon == 1.0
+    assert g2.title == "My Life"
+    assert g2.title_fontsize == 24
+    assert g2.watermark_text == "DRAFT"
+    assert g2.draw_max_age is True
+    assert len(g2._event_records) == 2
+    assert len(g2._era_records) == 1
+    assert len(g2._era_span_records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Color round-trip
+# ---------------------------------------------------------------------------
+
+def test_color_roundtrip(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100, max_age=50)
+    g.add_life_event("Hex", datetime.date(2000, 6, 1), color="#FF0000")
+    g.add_life_event("Tuple", datetime.date(2001, 6, 1), color=(0.5, 0.25, 0.1))
+
+    path = tmp_path / "colors.json"
+    g.save_config(str(path))
+
+    g2 = Lifegraph.from_config(str(path))
+    assert g2._event_records[0]["color"] == "#FF0000"
+    assert g2._event_records[1]["color"] == (0.5, 0.25, 0.1)
+
+
+# ---------------------------------------------------------------------------
+# Hint round-trip
+# ---------------------------------------------------------------------------
+
+def test_hint_roundtrip(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100, max_age=50)
+    g.add_life_event("With hint", datetime.date(2000, 6, 1), color="red",
+                     hint=Point(25, -3))
+
+    path = tmp_path / "hints.json"
+    g.save_config(str(path))
+
+    raw = json.loads(path.read_text())
+    assert raw["events"][0]["hint"] == [25, -3]
+
+    g2 = Lifegraph.from_config(str(path))
+    hint = g2._event_records[0]["hint"]
+    assert isinstance(hint, Point)
+    assert hint.x == 25
+    assert hint.y == -3
+
+
+# ---------------------------------------------------------------------------
+# Side round-trip
+# ---------------------------------------------------------------------------
+
+def test_side_roundtrip(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100, max_age=50)
+    g.add_life_event("Left", datetime.date(2000, 6, 1), color="red", side=Side.LEFT)
+    g.add_life_event("Right", datetime.date(2001, 6, 1), color="blue", side=Side.RIGHT)
+
+    path = tmp_path / "sides.json"
+    g.save_config(str(path))
+
+    raw = json.loads(path.read_text())
+    assert raw["events"][0]["side"] == "left"
+    assert raw["events"][1]["side"] == "right"
+
+    g2 = Lifegraph.from_config(str(path))
+    assert g2._event_records[0]["side"] == Side.LEFT
+    assert g2._event_records[1]["side"] == Side.RIGHT
+
+
+# ---------------------------------------------------------------------------
+# Styling included + applied
+# ---------------------------------------------------------------------------
+
+def test_styling_included_and_applied(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100)
+    g.format_x_axis(text="Weeks", positionx=0.3, positiony=1.1, color="red", fontsize=14)
+    g.format_y_axis(text="Age", positionx=-0.05, positiony=0.9, color="green", fontsize=16)
+
+    path = tmp_path / "styled.json"
+    g.save_config(str(path), include_styling=True)
+
+    g2 = Lifegraph.from_config(str(path))
+    assert g2.xaxis_label == "Weeks"
+    assert g2.settings.otherParams["xlabel.position"] == (0.3, 1.1)
+    assert g2.settings.otherParams["xlabel.color"] == "red"
+    assert g2.settings.otherParams["xlabel.fontsize"] == 14
+    assert g2.yaxis_label == "Age"
+    assert g2.settings.otherParams["ylabel.position"] == (-0.05, 0.9)
+    assert g2.settings.otherParams["ylabel.color"] == "green"
+    assert g2.settings.otherParams["ylabel.fontsize"] == 16
+
+
+# ---------------------------------------------------------------------------
+# Styling included + NOT applied
+# ---------------------------------------------------------------------------
+
+def test_styling_not_applied(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100)
+    g.format_x_axis(text="Weeks")
+
+    path = tmp_path / "styled2.json"
+    g.save_config(str(path), include_styling=True)
+
+    g2 = Lifegraph.from_config(str(path), apply_styling=False)
+    # Default x-axis label, not the custom one
+    assert g2.xaxis_label == r'Week of the Year $\longrightarrow$'
+
+
+# ---------------------------------------------------------------------------
+# Styling not included
+# ---------------------------------------------------------------------------
+
+def test_styling_not_included(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100)
+    g.format_x_axis(text="Weeks")
+
+    path = tmp_path / "no_style.json"
+    g.save_config(str(path), include_styling=False)
+
+    raw = json.loads(path.read_text())
+    assert "styling" not in raw
+
+
+# ---------------------------------------------------------------------------
+# YAML round-trip
+# ---------------------------------------------------------------------------
+
+def test_yaml_roundtrip(tmp_path):
+    pytest.importorskip("yaml")
+
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100, max_age=50)
+    g.add_life_event("Test", datetime.date(2000, 6, 1), color="red")
+
+    for ext in (".yaml", ".yml"):
+        path = tmp_path / f"config{ext}"
+        g.save_config(str(path))
+
+        g2 = Lifegraph.from_config(str(path))
+        assert g2.birthdate == datetime.date(1990, 1, 1)
+        assert len(g2._event_records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Defaults omitted
+# ---------------------------------------------------------------------------
+
+def test_defaults_omitted(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=300, max_age=90)
+    g.add_life_event("Ev", datetime.date(2000, 6, 1), color="red", color_square=True)
+    g.add_era("Era", datetime.date(2000, 1, 1), datetime.date(2005, 1, 1),
+              color="blue", alpha=0.3)
+
+    path = tmp_path / "defaults.json"
+    g.save_config(str(path))
+
+    raw = json.loads(path.read_text())
+
+    # Constructor defaults omitted
+    assert "max_age" not in raw
+    assert "dpi" not in raw
+    assert "size" not in raw
+
+    # color_square=True (default) omitted
+    assert "color_square" not in raw["events"][0]
+
+    # alpha=0.3 (default) omitted
+    assert "alpha" not in raw["eras"][0]
+
+
+# ---------------------------------------------------------------------------
+# Title as bare string
+# ---------------------------------------------------------------------------
+
+def test_title_bare_string(tmp_path):
+    path = tmp_path / "bare_title.json"
+    path.write_text(json.dumps({
+        "version": CONFIG_VERSION,
+        "birthdate": "1990-01-01",
+        "title": "Hello World"
+    }))
+
+    g = Lifegraph.from_config(str(path))
+    assert g.title == "Hello World"
+    assert g.title_fontsize is None
+
+
+# ---------------------------------------------------------------------------
+# Unsupported extension error
+# ---------------------------------------------------------------------------
+
+def test_save_config_unsupported_ext(tmp_path):
+    g = Lifegraph(datetime.date(1990, 1, 1), dpi=100)
+    with pytest.raises(ValueError, match="Unsupported"):
+        g.save_config(str(tmp_path / "bad.txt"))
+
+
+def test_from_config_unsupported_ext(tmp_path):
+    with pytest.raises(ValueError, match="Unsupported"):
+        Lifegraph.from_config(str(tmp_path / "bad.txt"))
+
+
+# ---------------------------------------------------------------------------
+# Unsupported version error
+# ---------------------------------------------------------------------------
+
+def test_unsupported_version(tmp_path):
+    path = tmp_path / "bad_version.json"
+    path.write_text(json.dumps({
+        "version": 99,
+        "birthdate": "1990-01-01"
+    }))
+
+    with pytest.raises(ValueError, match="Unsupported config version"):
+        Lifegraph.from_config(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Render after import
+# ---------------------------------------------------------------------------
+
+def test_render_after_import(tmp_path):
+    g = Lifegraph(datetime.date(1995, 11, 20), dpi=100, size=Papersize.Letter, max_age=50)
+    g.add_life_event("Won award", datetime.date(2013, 11, 20), "#014421")
+    g.add_era("College", datetime.date(2014, 9, 1), datetime.date(2018, 12, 14), "blue")
+    g.add_era_span("Vacation", datetime.date(2016, 8, 22), datetime.date(2016, 12, 16), "#D2691E")
+    g.add_title("Test")
+
+    config_path = tmp_path / "render.json"
+    g.save_config(str(config_path))
+
+    g2 = Lifegraph.from_config(str(config_path))
+    img_path = tmp_path / "render.png"
+    g2.save(str(img_path))
+
+    assert img_path.exists()
+    assert img_path.stat().st_size > 0
+    g2.close()


### PR DESCRIPTION
Enable saving a Lifegraph to a portable config file (JSON or YAML) and recreating it later via `g.save_config()` and `Lifegraph.from_config()`. Original call arguments are recorded in private `_*_records` lists so exports are deterministic and round-trippable. YAML support is an optional dependency (pyyaml).